### PR TITLE
Streamline Chiefs Of Stuff landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Chiefs Of Stuff</title>
+    <meta
+      name="description"
+      content="Chiefs Of Stuff is a community for early-stage generalist operators."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&family=Work+Sans:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <span class="hero__emoji" aria-hidden="true">👷‍♂️</span>
+        <p class="hero__tagline">Community for early-stage generalist operators</p>
+        <h1>Chiefs Of Stuff</h1>
+      </header>
+
+      <main class="content">
+        <section class="block" id="about">
+          <h2>About</h2>
+          <p>
+            Chiefs Of Stuff is a community of hundreds of like-minded early-stage generalist
+            operators.
+          </p>
+          <p>
+            We exchange best practice, discuss current topics as well as job opportunities,
+            organise events and meet up regularly across our different hubs.
+          </p>
+        </section>
+
+        <section class="block" id="application">
+          <h2>Application</h2>
+          <p>Please apply via our form.</p>
+          <p>We review applications periodically and will be in touch soon.</p>
+        </section>
+
+        <section class="block" id="faq">
+          <div class="block__header">
+            <h2>FAQ</h2>
+            <p>Tap to open questions and learn more.</p>
+          </div>
+          <div class="faq">
+            <details>
+              <summary>Who is this for? Could I be a Chief?</summary>
+              <p>
+                This community is built around early-stage generalists in roles such as Chief of
+                Staff, Founders’ Associate and Entrepreneur in Residence. While we consider every
+                profile carefully, we only accept applicants who are in these roles already or have
+                made an impact in such a role recently.
+              </p>
+            </details>
+            <details>
+              <summary>Where are Chiefs based?</summary>
+              <p>
+                Although, our community exists remotely in our Slack space, we truly value
+                in-person interactions. This is why we meet up across our different hubs regularly
+                and organise events. You will currently find most Chiefs based in and around Berlin,
+                Munich and London. Please do not hesitate to join if your city is not currently
+                represented. The number of hubs is constantly increasing!
+              </p>
+            </details>
+            <details>
+              <summary>How long will it take for my application to be reviewed?</summary>
+              <p>
+                Since there has been increasing interest in joining the community, we would like to
+                ask you to be patient when waiting for feedback on your application. We are truly
+                trying our best to revert as soon as possible.
+              </p>
+            </details>
+            <details>
+              <summary>Does this cost anything?</summary>
+              <p>Definitely not. We do not aim to be a members club.</p>
+            </details>
+            <details>
+              <summary>Who is this run by?</summary>
+              <p>
+                This community is decentralised and primarily run by its own members. It was founded
+                by Jannick, who was later joined by Damian. They manage applications and other
+                high-level tasks. Both of them are (former) early-stage generalists and excited to
+                build this community with the strong support of all Chiefs.
+              </p>
+            </details>
+            <details>
+              <summary>How do I get in touch?</summary>
+              <p>
+                You can connect with us and follow the journey on LinkedIn and Twitter. For any
+                enquiries not related to membership and applications, please feel free to reach out
+                to us via hi@chiefsofstuff.com.
+              </p>
+            </details>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <p>👷‍♂️ Built by Chiefs for Chiefs Of Stuff</p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,178 @@
+:root {
+  color-scheme: dark light;
+  --bg: #070708;
+  --fg: #f5f5f5;
+  --muted: rgba(245, 245, 245, 0.72);
+  --accent: #ffe15a;
+  --card: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Work Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  display: flex;
+  min-height: 100vh;
+  justify-content: center;
+}
+
+.page {
+  width: min(720px, 100%);
+  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 4.5rem);
+}
+
+.hero {
+  display: grid;
+  justify-items: start;
+  gap: 1rem;
+}
+
+.hero__emoji {
+  font-size: clamp(3rem, 12vw, 4.5rem);
+  filter: drop-shadow(0 12px 24px rgba(255, 225, 90, 0.2));
+}
+
+.hero__tagline {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.75rem, 8vw, 4.5rem);
+  font-family: "Space Grotesk", "Work Sans", sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.block {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  backdrop-filter: blur(16px);
+}
+
+.block h2 {
+  margin: 0;
+  font-family: "Space Grotesk", "Work Sans", sans-serif;
+  font-size: 1.45rem;
+  letter-spacing: -0.01em;
+}
+
+.block__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.block__header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.block p {
+  margin: 0;
+  font-size: 1.02rem;
+  color: var(--muted);
+}
+
+.faq {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+details {
+  border-radius: 16px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+details[open] {
+  border-color: var(--accent);
+  background: rgba(255, 225, 90, 0.08);
+}
+
+details > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 1rem 1.1rem 1rem 1.1rem;
+  font-weight: 500;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+details > summary::after {
+  content: "+";
+  font-size: 1.25rem;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+details[open] > summary::after {
+  transform: rotate(45deg);
+}
+
+details p {
+  margin: 0;
+  padding: 0 1.1rem 1.1rem 1.1rem;
+  color: var(--fg);
+  font-size: 0.98rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.footer p {
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the page as a concise layout featuring the 👷‍♂️ hero, About, Application, and FAQ sections with the provided copy
- style the site with a minimalist dark treatment and interactive accordion FAQ while removing the previous long-form sections

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0111d9150832eabc0ea8845e63367