### PR TITLE
Adjust hero hierarchy and tighten spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,27 +20,23 @@
     <div class="page">
       <header class="hero">
         <span class="hero__emoji" aria-hidden="true">👷‍♂️</span>
-        <p class="hero__tagline">Community for early-stage generalist operators</p>
         <h1>Chiefs Of Stuff</h1>
+        <p class="hero__tagline">COMMUNITY FOR EARLY-STAGE GENERALIST OPERATORS</p>
       </header>
 
       <main class="content">
         <section class="block" id="about">
           <h2>About</h2>
+          <p>Chiefs Of Stuff unites hundreds of early-stage generalist operators.</p>
           <p>
-            Chiefs Of Stuff is a community of hundreds of like-minded early-stage generalist
-            operators.
-          </p>
-          <p>
-            We exchange best practice, discuss current topics as well as job opportunities,
-            organise events and meet up regularly across our different hubs.
+            We swap playbooks, surface opportunities, and meet regularly across our growing hubs.
           </p>
         </section>
 
         <section class="block" id="application">
           <h2>Application</h2>
-          <p>Please apply via our form.</p>
-          <p>We review applications periodically and will be in touch soon.</p>
+          <p>Apply via our form and we’ll review it promptly.</p>
+          <p>We’ll get back to you as soon as we can.</p>
         </section>
 
         <section class="block" id="faq">

--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,7 @@ body {
   padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem) 3rem;
   display: flex;
   flex-direction: column;
-  gap: clamp(3rem, 6vw, 4.5rem);
+  gap: clamp(2.25rem, 4vw, 3.5rem);
 }
 
 .hero {
@@ -64,14 +64,14 @@ h1 {
 .content {
   display: flex;
   flex-direction: column;
-  gap: clamp(2.5rem, 5vw, 3.5rem);
+  gap: clamp(1.75rem, 4vw, 2.75rem);
 }
 
 .block {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: clamp(1.5rem, 3vw, 2rem);
+  gap: 0.85rem;
+  padding: clamp(1.25rem, 2.75vw, 1.75rem);
   border-radius: 20px;
   border: 1px solid var(--border);
   background: var(--card);


### PR DESCRIPTION
## Summary
- move the hero tagline beneath the title and update the hero/application copy
- reduce spacing between content blocks to bring cards closer together

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0153e95f4832e8e25c9a76e0b0250