### PR TITLE
Condense layout and add hero apply CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,21 +22,18 @@
         <span class="hero__emoji" aria-hidden="true">👷‍♂️</span>
         <h1>Chiefs Of Stuff</h1>
         <p class="hero__tagline">COMMUNITY FOR EARLY-STAGE GENERALIST OPERATORS</p>
+        <a class="hero__cta" href="https://docs.google.com/forms/d/e/1FAIpQLScVjd72edLj9jmml4BYjmYHdINsB1w1xveB1CrrwSnCJYDfVw/viewform">
+          Apply now
+        </a>
       </header>
 
       <main class="content">
         <section class="block" id="about">
           <h2>About</h2>
-          <p>Chiefs Of Stuff unites hundreds of early-stage generalist operators.</p>
+          <p>Chiefs Of Stuff brings together early-stage operators to trade playbooks and open doors.</p>
           <p>
-            We swap playbooks, surface opportunities, and meet regularly across our growing hubs.
+            Join to connect with peers, share wins, and tap into meetups across our growing hubs.
           </p>
-        </section>
-
-        <section class="block" id="application">
-          <h2>Application</h2>
-          <p>Apply via our form and we’ll review it promptly.</p>
-          <p>We’ll get back to you as soon as we can.</p>
         </section>
 
         <section class="block" id="faq">
@@ -48,28 +45,24 @@
             <details>
               <summary>Who is this for? Could I be a Chief?</summary>
               <p>
-                This community is built around early-stage generalists in roles such as Chief of
-                Staff, Founders’ Associate and Entrepreneur in Residence. While we consider every
-                profile carefully, we only accept applicants who are in these roles already or have
-                made an impact in such a role recently.
+                Chiefs Of Stuff is for early-stage generalists—Chiefs of Staff, Founders’ Associates,
+                Entrepreneurs in Residence—who are actively shaping young companies. We welcome
+                operators already in these seats or recently driving impact in them.
               </p>
             </details>
             <details>
               <summary>Where are Chiefs based?</summary>
               <p>
-                Although, our community exists remotely in our Slack space, we truly value
-                in-person interactions. This is why we meet up across our different hubs regularly
-                and organise events. You will currently find most Chiefs based in and around Berlin,
-                Munich and London. Please do not hesitate to join if your city is not currently
-                represented. The number of hubs is constantly increasing!
+                We connect daily in Slack and meet up often in our hubs across Berlin, Munich, and
+                London—with new cities joining in all the time. Jump in even if your home base isn’t
+                listed yet.
               </p>
             </details>
             <details>
               <summary>How long will it take for my application to be reviewed?</summary>
               <p>
-                Since there has been increasing interest in joining the community, we would like to
-                ask you to be patient when waiting for feedback on your application. We are truly
-                trying our best to revert as soon as possible.
+                Demand is high, but we review submissions every week and respond as quickly as we
+                can.
               </p>
             </details>
             <details>
@@ -79,18 +72,19 @@
             <details>
               <summary>Who is this run by?</summary>
               <p>
-                This community is decentralised and primarily run by its own members. It was founded
-                by Jannick, who was later joined by Damian. They manage applications and other
-                high-level tasks. Both of them are (former) early-stage generalists and excited to
-                build this community with the strong support of all Chiefs.
+                This community is decentralised and primarily run by its members. It was founded by
+                <a href="https://www.linkedin.com/in/jannickstein/">Jannick</a>, later joined by
+                <a href="https://www.linkedin.com/in/d-zak">Damian</a>. They guide applications and
+                keep Chiefs moving forward together.
               </p>
             </details>
             <details>
               <summary>How do I get in touch?</summary>
               <p>
-                You can connect with us and follow the journey on LinkedIn and Twitter. For any
-                enquiries not related to membership and applications, please feel free to reach out
-                to us via hi@chiefsofstuff.com.
+                Connect with us on
+                <a href="https://www.linkedin.com/company/chiefsofstuff">LinkedIn</a> and
+                <a href="https://x.com/ChiefsOfStuff">Twitter</a>. For any other enquiries, reach
+                us at hi@chiefsofstuff.com.
               </p>
             </details>
           </div>
@@ -98,7 +92,7 @@
       </main>
 
       <footer class="footer">
-        <p>👷‍♂️ Built by Chiefs for Chiefs Of Stuff</p>
+        <p>Built by Chiefs for Chiefs 👷‍♂️</p>
       </footer>
     </div>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -29,17 +29,17 @@ body {
 }
 
 .page {
-  width: min(720px, 100%);
-  padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem) 3rem;
+  width: min(680px, 100%);
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 4vw, 2.5rem) 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: clamp(2.25rem, 4vw, 3.5rem);
+  gap: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .hero {
   display: grid;
   justify-items: start;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .hero__emoji {
@@ -54,6 +54,27 @@ body {
   color: var(--muted);
 }
 
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.15rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #1e1e1e;
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px rgba(255, 225, 90, 0.18);
+}
+
+.hero__cta:hover,
+.hero__cta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(255, 225, 90, 0.22);
+}
+
 h1 {
   margin: 0;
   font-size: clamp(2.75rem, 8vw, 4.5rem);
@@ -64,14 +85,14 @@ h1 {
 .content {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.75rem, 4vw, 2.75rem);
+  gap: clamp(1.1rem, 3vw, 1.75rem);
 }
 
 .block {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: clamp(1.25rem, 2.75vw, 1.75rem);
+  gap: 0.6rem;
+  padding: clamp(1rem, 2.4vw, 1.5rem);
   border-radius: 20px;
   border: 1px solid var(--border);
   background: var(--card);
@@ -88,7 +109,7 @@ h1 {
 .block__header {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .block__header p {
@@ -99,14 +120,14 @@ h1 {
 
 .block p {
   margin: 0;
-  font-size: 1.02rem;
+  font-size: 0.98rem;
   color: var(--muted);
 }
 
 .faq {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 details {


### PR DESCRIPTION
## Summary
- add a hero apply button linking to the application form so it appears before scrolling
- tighten copy and integrate required LinkedIn and Twitter links across the FAQ
- condense spacing and card styling for a more compact layout with updated footer message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0178ae9dc832ea07c6b8a7cff5f3c