### PR TITLE
Adjust hero spacing and unify link styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@
         <section class="block" id="faq">
           <div class="block__header">
             <h2>FAQ</h2>
-            <p>Tap to open questions and learn more.</p>
           </div>
           <div class="faq">
             <details>

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,17 @@ body {
   justify-content: center;
 }
 
+a {
+  color: var(--accent);
+  text-decoration-color: rgba(255, 225, 90, 0.7);
+}
+
+a:hover,
+a:focus-visible {
+  color: #ffef99;
+  text-decoration-color: rgba(255, 239, 153, 0.9);
+}
+
 .page {
   width: min(680px, 100%);
   padding: clamp(2rem, 4vw, 3rem) clamp(1.25rem, 4vw, 2.5rem) 2.5rem;
@@ -39,7 +50,7 @@ body {
 .hero {
   display: grid;
   justify-items: start;
-  gap: 0.75rem;
+  gap: clamp(0.55rem, 2.2vw, 0.8rem);
 }
 
 .hero__emoji {
@@ -61,7 +72,7 @@ body {
   padding: 0.65rem 1.15rem;
   border-radius: 999px;
   background: var(--accent);
-  color: #1e1e1e;
+  color: #1a1a1a;
   font-weight: 600;
   text-decoration: none;
   font-size: 0.95rem;
@@ -80,6 +91,7 @@ h1 {
   font-size: clamp(2.75rem, 8vw, 4.5rem);
   font-family: "Space Grotesk", "Work Sans", sans-serif;
   letter-spacing: -0.02em;
+  line-height: 1.05;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- bring the hero headline and tagline closer together and refresh the call-to-action styling
- remove redundant FAQ helper copy and standardize hyperlink colors across the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01925039c832eb0d89a1e63056186