### PR TITLE
Make hero apply link text yellow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ a:focus-visible {
   padding: 0.7rem 1.5rem;
   border-radius: 999px;
   background: linear-gradient(135deg, #ffe15a, #ffd84d);
-  color: #1a1a1a;
+  color: #ffe15a;
   font-weight: 600;
   text-decoration: none;
   font-size: 1rem;
@@ -85,7 +85,7 @@ a:focus-visible {
 }
 
 .hero__cta:visited {
-  color: #1a1a1a;
+  color: #ffe15a;
 }
 
 .hero__cta:hover,


### PR DESCRIPTION
## Summary
- update the hero call-to-action link color to yellow for default and visited states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e032b85918832eb412f2daedac340a