### PR TITLE
Adjust CTA text color for better readability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,7 +74,7 @@ a:focus-visible {
   padding: 0.7rem 1.5rem;
   border-radius: 999px;
   background: linear-gradient(135deg, #ffe15a, #ffd84d);
-  color: #ffe15a;
+  color: #000000;
   font-weight: 600;
   text-decoration: none;
   font-size: 1rem;
@@ -85,7 +85,7 @@ a:focus-visible {
 }
 
 .hero__cta:visited {
-  color: #ffe15a;
+  color: #000000;
 }
 
 .hero__cta:hover,


### PR DESCRIPTION
## Summary
- update the hero CTA styles to use black text for normal and visited states for improved contrast

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0339674f8832e93bb84e3c3548622